### PR TITLE
Feat/fill c2l

### DIFF
--- a/bin/integrate_anndata.py
+++ b/bin/integrate_anndata.py
@@ -143,6 +143,7 @@ def concat_matrix_from_cell2location(
     concat_feature_name: str = "celltype",
     sort: bool = True,
     sort_index: str = None,
+    fill_missing: bool = False,
     **kwargs,
 ):
     sort = sort or sort_index is not None
@@ -185,7 +186,15 @@ def concat_matrix_from_cell2location(
                     )
                 idx = c2l_adata.obs.index.get_indexer(data_idx.tolist())
                 if -1 in idx:
-                    raise Exception("Non-matching indices present.")
+                    if not fill_missing:
+                        raise Exception("Non-matching indices present.")
+                    else:
+                        logging.info(
+                            "Filling missing indices in cell2location output with NaN values."
+                        )
+                        c2l_adata, idx = fill_missing_indices(
+                            idx, data_idx, adata, c2l_adata, sort_index
+                        )
             except Exception:
                 raise SystemError(
                     "Failed to find a match between indices as substrings."
@@ -311,8 +320,20 @@ def write_anndata(
 
 def match_substring_indices(fullstring_idx, substring_idx):
     return pd.Series(substring_idx).apply(
-        lambda x: fullstring_idx[fullstring_idx.str.contains(x)].values[0]
+        lambda x: (
+            lambda y=fullstring_idx[fullstring_idx.str.contains(x)]: (
+                y.values[0] if len(y.values) else x
+            )
+        )()
     )
+
+
+def fill_missing_indices(idx, data_idx, adata, c2l_adata, sort_index):
+    adata_missing = ad.AnnData(obs=pd.DataFrame(adata.obs.iloc[idx == -1][sort_index]))
+    adata_missing.obs.set_index(sort_index, inplace=True)
+    c2l_adata_w_missing = ad.concat([c2l_adata, adata_missing], join="outer")
+    idx = c2l_adata_w_missing.obs.index.get_indexer(data_idx.tolist())
+    return c2l_adata_w_missing, idx
 
 
 if __name__ == "__main__":

--- a/bin/integrate_anndata.py
+++ b/bin/integrate_anndata.py
@@ -3,6 +3,7 @@
 from typing import Union
 import typing as T
 import os
+import gc
 import fire
 import zarr
 import h5py
@@ -98,6 +99,9 @@ def intersect_features(*paths, **kwargs):
         )
 
         write_anndata(adata, out_filename, **kwargs)
+
+        del adata
+        gc.collect()
 
     return
 
@@ -291,6 +295,7 @@ def get_feature_intersection(*paths):
                 var_indices.append(ad._io.h5ad.read_elem(f["var"]).index.to_series())
 
     var_intersect = pd.concat(var_indices, axis=1, join="inner").index
+    logging.info(f"Got intersection of {len(var_intersect)} features")
 
     return var_intersect
 

--- a/bin/process_h5ad.py
+++ b/bin/process_h5ad.py
@@ -189,7 +189,13 @@ def preprocess_anndata(
 
     # reindex var with a specified column
     if var_index and var_index in adata.var:
-        adata.var.reset_index(inplace=True)
+        try:
+            adata.var.reset_index(inplace=True)
+        except ValueError:
+            logging.warning(
+                "Column already exists when trying to reset var index. Dropping index."
+            )
+            adata.var.reset_index(inplace=True, drop=True)
         adata.var.set_index(var_index, inplace=True)
         adata.var.index = adata.var.index.astype(str)
     adata.var_names_make_unique()

--- a/bin/process_spaceranger.py
+++ b/bin/process_spaceranger.py
@@ -52,9 +52,9 @@ def spaceranger_to_anndata(
 
     adata = sc.read_visium(
         p,
-        count_file="raw_feature_bc_matrix.h5"
-        if load_raw
-        else "filtered_feature_bc_matrix.h5",
+        count_file=(
+            "raw_feature_bc_matrix.h5" if load_raw else "filtered_feature_bc_matrix.h5"
+        ),
     )
 
     if load_clusters:
@@ -132,7 +132,7 @@ def visium_label(
     stem: str,
     file_path: str,
     shape: tuple[int, int] = None,
-    obs_subset: tuple[int, T.Any] = None,
+    obs_subset: tuple[str, T.Any] = None,
     sample_id: str = None,
     relative_size: str = None,
 ) -> None:


### PR DESCRIPTION
- add paremeter `fill_missing` when concatenating from cell2location output. To allow c2l output that have less obs to be concatenated filling missing values with nans. defaults to false and throws an error if not same obs length
- handle exception in anndata preprocessing where resetting the index fails as a column with its name already exists. Drops the index instead
- explicitly call `gc.collect()` when iteratively writing intersected anndatas